### PR TITLE
Codes for the 1D Experiments

### DIFF
--- a/mtecg/__init__.py
+++ b/mtecg/__init__.py
@@ -8,7 +8,9 @@ from .io import *
 from .predict import *
 from .utils import *
 from .models import *
+from .models_1d	import *
 from .datasets import *
+from .datasets_1d import *
 
 # from .evaluation import *
 # from .classifier import *

--- a/mtecg/constants.py
+++ b/mtecg/constants.py
@@ -4,6 +4,7 @@ filename_column_name = "file_name"
 run_number_column_name = "run_num"
 train_column_name = "train_80_percent"
 dev_column_name = "develop_10_percent"
+data_arrays_column_name = 'lead_arrays'
 
 scar_label_column_name = "scar_cad"
 lvef_label_column_name = "lvef"

--- a/mtecg/datasets_1d.py
+++ b/mtecg/datasets_1d.py
@@ -1,0 +1,106 @@
+import numpy as np
+import pandas as pd
+from PIL import Image
+
+import pickle
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.utils.data import DataLoader, Dataset
+from torchmetrics import Accuracy
+from scipy.signal import resample
+from sklearn.preprocessing import StandardScaler
+
+from mtecg.utils import categorize_lvef
+import mtecg.constants as constants
+
+
+class ECG1DDataset(Dataset):
+    def __init__(self, dataframe: pd.DataFrame, lead_arrays_column: str = "lead_arrays", label_column: str = "scar_cad"):
+        self.lead_arrays_list = list(dataframe[lead_arrays_column])
+        self.label_list = list(dataframe[label_column])
+
+    def __len__(self):
+        return len(self.lead_arrays_list)
+
+    def __getitem__(self, index):
+        lead_arrays = self.lead_arrays_list[index]
+        label = self.label_list[index]
+        return torch.tensor(lead_arrays, dtype=torch.float32), label
+
+
+class ECGClinical1DDataset(ECG1DDataset):
+    def __init__(self, dataframe, lead_arrays_column: str = "lead_arrays", label_column: str = "scar_cad"):
+        super(ECGClinical1DDataset, self).__init__(dataframe, lead_arrays_column, label_column)
+
+        # Drop path, label, and numerical clinical features (age).
+        self.categorical_feature_dataframe = dataframe[constants.categorical_feature_column_names]
+        self.numerical_feature_dataframe = dataframe[[constants.age_column_name]]
+
+    def __getitem__(self, index):
+        ### numerical clinical features should be separeted from categorical clinical features
+        lead_arrays, numerical_feature, categorical_features, label = (
+            self.lead_arrays_list[index],
+            self.numerical_feature_dataframe.iloc[[index]].to_numpy(),
+            self.categorical_feature_dataframe.iloc[[index]].to_numpy(),
+            self.labels[index],
+        )
+
+        ### result format (x_lead_arrays, x_numerical, x_categorical), y
+        return (
+            (
+                torch.tensor(lead_arrays, dtype=torch.float32),
+                torch.tensor(numerical_feature, dtype=torch.float32),
+                torch.tensor(categorical_features, dtype=torch.long),
+            ),
+            label,
+        )
+
+
+class MultiTask1DDataset(Dataset):
+    def __init__(self, dataframe: pd.DataFrame, lead_arrays_column: str = "lead_arrays"):
+        self.lead_arrays_list = list(dataframe[lead_arrays_column])
+
+        scar_labels = list(dataframe[constants.scar_label_column_name])
+        lvef_labels = list(dataframe[constants.lvef_label_column_name])
+
+        self.labels = list(zip(scar_labels, lvef_labels))
+
+    def __len__(self):
+        return len(self.lead_arrays_list)
+
+    def __getitem__(self, index):
+        # dealing with the image 
+        lead_arrays, label = self.lead_arrays_list[index], self.labels[index]
+        return torch.tensor(lead_arrays, dtype=torch.float32), {
+            "scar": torch.tensor(label[0], dtype=torch.long),
+            "lvef": torch.tensor(label[1], dtype=torch.long),
+        }
+
+
+class MultiTaskClinical1DDataset(MultiTask1DDataset):
+    def __init__(self, dataframe, lead_arrays_column: str = "lead_arrays"):
+        super(MultiTaskClinical1DDataset, self).__init__(dataframe, lead_arrays_column)
+
+        # Drop path, label, and numerical clinical features (age).
+        self.categorical_feature_dataframe = dataframe[constants.categorical_feature_column_names]
+        self.numerical_feature_dataframe = dataframe[[constants.age_column_name]]
+
+    def __getitem__(self, index):
+        ### numerical clinical features should be separeted from categorical clinical features
+        lead_arrays, numerical_feature, categorical_features, label = (
+            self.lead_arrays_list[index],
+            self.numerical_feature_dataframe.iloc[[index]].to_numpy(),
+            self.categorical_feature_dataframe.iloc[[index]].to_numpy(),
+            self.labels[index],
+        )
+
+        ### result format (x_lead_arrays, x_numerical, x_categorical), y
+        return (
+            (
+                torch.tensor(lead_arrays, dtype=torch.float32),
+                torch.tensor(numerical_feature, dtype=torch.float32),
+                torch.tensor(categorical_features, dtype=torch.long),
+            ),
+            {"scar": torch.tensor(label[0], dtype=torch.long), "lvef": torch.tensor(label[1], dtype=torch.long)},
+        )

--- a/mtecg/datasets_1d.py
+++ b/mtecg/datasets_1d.py
@@ -43,7 +43,7 @@ class ECGClinical1DDataset(ECG1DDataset):
             self.lead_arrays_list[index],
             self.numerical_feature_dataframe.iloc[[index]].to_numpy(),
             self.categorical_feature_dataframe.iloc[[index]].to_numpy(),
-            self.labels[index],
+            self.label_list[index],
         )
 
         ### result format (x_lead_arrays, x_numerical, x_categorical), y
@@ -64,14 +64,14 @@ class MultiTask1DDataset(Dataset):
         scar_labels = list(dataframe[constants.scar_label_column_name])
         lvef_labels = list(dataframe[constants.lvef_label_column_name])
 
-        self.labels = list(zip(scar_labels, lvef_labels))
+        self.label_list = list(zip(scar_labels, lvef_labels))
 
     def __len__(self):
         return len(self.lead_arrays_list)
 
     def __getitem__(self, index):
         # dealing with the image 
-        lead_arrays, label = self.lead_arrays_list[index], self.labels[index]
+        lead_arrays, label = self.lead_arrays_list[index], self.label_list[index]
         return torch.tensor(lead_arrays, dtype=torch.float32), {
             "scar": torch.tensor(label[0], dtype=torch.long),
             "lvef": torch.tensor(label[1], dtype=torch.long),
@@ -92,7 +92,7 @@ class MultiTaskClinical1DDataset(MultiTask1DDataset):
             self.lead_arrays_list[index],
             self.numerical_feature_dataframe.iloc[[index]].to_numpy(),
             self.categorical_feature_dataframe.iloc[[index]].to_numpy(),
-            self.labels[index],
+            self.label_list[index],
         )
 
         ### result format (x_lead_arrays, x_numerical, x_categorical), y

--- a/mtecg/models_1d.py
+++ b/mtecg/models_1d.py
@@ -1,0 +1,197 @@
+import os.path as op
+import json
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torchmetrics import Accuracy
+from typing import Union
+
+import torchvision.models as models
+from pytorch_lightning import LightningModule
+import timm
+
+from transformers import get_linear_schedule_with_warmup
+from .models import SingleTaskModel, MultiTaskModel, SingleTaskClinicalCNNModel, MultiTaskClinicalCNNModel
+
+NUM_ECG_LEADS = 12
+
+class LeadEmbeddingMixin:
+    def get_lead_embeddings(self, leads_batch):
+        # There are 12 leads in each ECG.
+        lead_embedding_list = []
+        for i in range(NUM_ECG_LEADS):
+            lead_batch = leads_batch[:, i, :].unsqueeze(1).unsqueeze(1)
+            lead_embedding = self.model(lead_batch)
+            lead_embedding_list.append(lead_embedding)
+
+        # Average the lead embeddings.
+        lead_embeddings = torch.mean(torch.stack(lead_embedding_list), dim=0)
+        return lead_embeddings
+
+
+class ClinicalEmbeddingMixin:
+    def get_feature_embeddings(self, numerical_features, categorical_features):
+        # Reshape numerical features.
+        numerical_features = numerical_features.reshape(-1, 1)
+        feature_embedding_list = []
+
+        categorical_features = torch.swapaxes(
+            categorical_features.view(categorical_features.size(0), categorical_features.size(-1)), 1, 0
+        )
+        for categorical_feature in categorical_features:
+            # Pass categorical feature through embedding layer.
+            categorical_embeddings = self.embedding_layer(categorical_feature)
+            # Concatenate raw numerical feature to the categorical embeddings.
+            feature_embeddings = torch.cat([categorical_embeddings, numerical_features], dim=1)
+            feature_embeddings = torch.unsqueeze(feature_embeddings, dim=0)
+            feature_embedding_list.append(feature_embeddings)
+
+        preprocessed_feature_embeddings = torch.cat(feature_embedding_list, dim=0)
+        if self.rnn_type == "rnn":
+            rnn_hidden_state_matrix = self.get_rnn_hidden_state(
+                (self.num_rnn_layers, preprocessed_feature_embeddings.size(1), self.rnn_output_size)
+            )
+            # Pass the preprocessed feature embeddings through the RNN layer
+            _, summarized_feature_embeddings = self.clinical_rnn_layer(
+                preprocessed_feature_embeddings, rnn_hidden_state_matrix
+            )
+        elif self.rnn_type == "lstm":
+            rnn_hidden_state_matrix = self.get_rnn_hidden_state(
+                (self.num_rnn_layers, preprocessed_feature_embeddings.size(1), self.rnn_output_size)
+            )
+            rnn_cell_state_matrix = self.get_rnn_hidden_state(
+                (self.num_rnn_layers, preprocessed_feature_embeddings.size(1), self.rnn_output_size)
+            )
+            # Pass the preprocessed feature embeddings through the LSTM layer
+            _, (summarized_feature_embeddings, _) = self.clinical_rnn_layer(
+                preprocessed_feature_embeddings, (rnn_hidden_state_matrix, rnn_cell_state_matrix)
+            )
+
+        elif self.rnn_type == "birnn":
+            rnn_hidden_state_matrix = self.get_rnn_hidden_state(
+                (self.num_rnn_layers * 2, preprocessed_feature_embeddings.size(1), self.rnn_output_size)
+            )
+            # Pass the preprocessed feature embeddings through the RNN layer
+            _, summarized_feature_embeddings = self.clinical_rnn_layer(
+                preprocessed_feature_embeddings, rnn_hidden_state_matrix
+            )
+
+            summarized_feature_embeddings = torch.sum(summarized_feature_embeddings, dim=0, keepdim=True)
+
+        elif self.rnn_type == "bilstm":
+            rnn_hidden_state_matrix = self.get_rnn_hidden_state(
+                (self.num_rnn_layers * 2, preprocessed_feature_embeddings.size(1), self.rnn_output_size)
+            )
+
+            rnn_cell_state_matrix = self.get_rnn_hidden_state(
+                (self.num_rnn_layers * 2, preprocessed_feature_embeddings.size(1), self.rnn_output_size)
+            )
+
+            # Pass the preprocessed feature embeddings through the LSTM layer
+            _, (summarized_feature_embeddings, _) = self.clinical_rnn_layer(
+                preprocessed_feature_embeddings, (rnn_hidden_state_matrix, rnn_cell_state_matrix)
+            )
+            summarized_feature_embeddings = torch.sum(summarized_feature_embeddings, dim=0, keepdim=True)
+
+        # Reshape the summarized feature embeddings.
+        summarized_feature_embeddings = summarized_feature_embeddings.view(
+            summarized_feature_embeddings.size(1), summarized_feature_embeddings.size(-1) * self.num_rnn_layers
+        )
+        return summarized_feature_embeddings
+
+
+class SingleTaskModel1D(SingleTaskModel, LeadEmbeddingMixin):
+    def __init__(self, num_leads: int = 12, **kwargs):
+        super().__init__(**kwargs)
+        self.num_leads = num_leads
+        self.model.conv1 = nn.Conv2d(1, 64, kernel_size=(1, 3), stride=1, padding=3)
+        self.save_hyperparameters()
+
+    def forward(self, leads_batch):
+        lead_embeddings = self.get_lead_embeddings(leads_batch)
+        lead_embeddings = F.relu(lead_embeddings)
+        out = self.head(lead_embeddings)
+        return out
+
+
+class MultiTaskModel1D(MultiTaskModel, LeadEmbeddingMixin):
+    def __init__(self, num_leads: int = 12, **kwargs):
+        super().__init__(**kwargs)
+        self.num_leads = num_leads
+        self.model.conv1 = nn.Conv2d(1, 64, kernel_size=(1, 3), stride=1, padding=3)
+        self.save_hyperparameters()
+
+    def forward(self, leads_batch):
+        lead_embeddings = self.get_lead_embeddings(leads_batch)
+        lead_embeddings = F.relu(lead_embeddings)
+        scar = self.scar_head(lead_embeddings)
+        lvef = self.lvef_head(lead_embeddings)
+        return torch.cat([scar, lvef], dim=1)
+
+
+class SingleTaskClinicalModel1D(SingleTaskClinicalCNNModel, LeadEmbeddingMixin, ClinicalEmbeddingMixin):
+    def __init__(self, num_leads: int = 12, **kwargs):
+        super().__init__(**kwargs)
+        self.num_leads = num_leads
+        self.model.conv1 = nn.Conv2d(1, 64, kernel_size=(1, 3), stride=1, padding=3)
+
+        self.model.fc = nn.Linear(in_features=num_in_features, out_features=latent_dim, bias=False)
+        self.head = nn.Linear(
+            in_features=self.rnn_output_size * num_rnn_layers + latent_dim,
+            out_features=num_classes,
+            bias=bias_head,
+        )
+        self.save_hyperparameters()
+
+    def forward(self, x):
+        """
+        x is a tuple with 3 elements:
+        1. x[0]: ECG lead arrays.
+        2. x[1]: numerical clinical features.
+        3. x[2]: categorical clinical features.
+        """
+        leads_batch, numerical_features, categorical_features = x
+
+        lead_embeddings = self.get_lead_embeddings(leads_batch)
+        summarized_feature_embeddings = self.get_feature_embeddings(numerical_features, categorical_features)
+
+        # Concatenate lead embeddings and summarized clinical features embeddings.([lead_embeddings, num_feat, cat1_emb, cat2_emb, ..., catn_emb])
+        embedding_list = [lead_embeddings, summarized_feature_embeddings]
+        embeddings = torch.cat(embedding_list, dim=1)
+        embeddings = F.relu(embeddings)
+        out = self.head(embeddings)
+        return out
+
+
+class MultiTaskClinicalModel1D(SingleTaskClinicalCNNModel, LeadEmbeddingMixin, ClinicalEmbeddingMixin):
+    def __init__(self, num_leads: int = 12, **kwargs):
+        super().__init__(**kwargs)
+        self.num_leads = num_leads
+        self.model.conv1 = nn.Conv2d(1, 64, kernel_size=(1, 3), stride=1, padding=3)
+
+        self.model.fc = nn.Linear(in_features=num_in_features, out_features=latent_dim, bias=False)
+        self.head = nn.Linear(
+            in_features=self.rnn_output_size * num_rnn_layers + latent_dim,
+            out_features=num_classes,
+            bias=bias_head,
+        )
+        self.save_hyperparameters()
+
+    def forward(self, x):
+        """
+        x is a tuple with 3 elements:
+        1. x[0]: ECG lead arrays.
+        2. x[1]: numerical clinical features.
+        3. x[2]: categorical clinical features.
+        """
+        leads_batch, numerical_features, categorical_features = x
+
+        lead_embeddings = self.get_lead_embeddings(leads_batch)
+        summarized_feature_embeddings = self.get_feature_embeddings(numerical_features, categorical_features)
+
+        # Concatenate lead embeddings and summarized clinical features embeddings.([lead_embeddings, num_feat, cat1_emb, cat2_emb, ..., catn_emb])
+        embedding_list = [lead_embeddings, summarized_feature_embeddings]
+        embeddings = torch.cat(embedding_list, dim=1)
+        embeddings = F.relu(embeddings)
+        out = self.head(embeddings)
+        return out

--- a/mtecg/utils.py
+++ b/mtecg/utils.py
@@ -83,10 +83,15 @@ def load_ecg_dataframe(
             axis=1,
         )
         # Replace \\ with / to avoid path issues.
-        image_dataframe[constants.path_column_name] = image_dataframe[constants.path_column_name].apply(
-            lambda x: x.replace("\\", "/")
+        dataframe[constants.path_column_name] = dataframe[constants.path_column_name].apply(
+            lambda x: x.replace('\\', '/')
         )
-        # Merge with the available images.
+        image_dataframe[constants.path_column_name] = image_dataframe[constants.path_column_name].apply(
+            lambda x: x.replace('\\', '/')
+        )
+
+        # # Merge with the available images.
+        # dataframe = dataframe.merge(image_dataframe, on=constants.path_column_name)
         dataframe = dataframe.merge(image_dataframe, on=constants.path_column_name)
 
     # Rename columns.
@@ -186,4 +191,110 @@ def apply_thresholds(
         dataframe.loc[dataframe[constants.impute_column_name] == True, imputed_column_name] = imputed_df[
             imputed_column_name
         ].values
+    return dataframe
+
+
+def load_ecg_dataframe_1d(
+    csv_path: str,
+    data_dir: str,
+    file_extension: str = "",
+    lvef_threshold: int = 50,
+    do_split: bool = True,
+    drop_impute: bool = False,
+    imputer_dir: str = None,
+    is_control_population: bool = False,
+    return_lvef_40_column: bool = False,
+) -> pd.DataFrame:
+
+    if not is_control_population:
+        dataframe = pd.read_csv(csv_path)
+        if "Unnamed: 0" in dataframe.columns:
+            dataframe.drop(columns=["Unnamed: 0"], inplace=True)
+    else:
+        dataframe = (
+            pd.read_csv(csv_path)
+            .drop(columns=[constants.path_column_name])
+            .rename(columns={"save_path": constants.path_column_name})
+        )
+        # Set all labels to 0 for control population.
+        dataframe[constants.scar_label_column_name] = 0
+        dataframe["LVEF"] = 100
+
+    # Lowercase column names for consistency.
+    dataframe.columns = map(str.lower, dataframe.columns)
+
+    if constants.cut_column_name in dataframe.columns:
+        dataframe = dataframe[dataframe[constants.cut_column_name] != 1].reset_index(drop=True)
+    if constants.impute_column_name in dataframe.columns and drop_impute:
+        dataframe = dataframe[dataframe[constants.impute_column_name] != 1].reset_index(drop=True)
+
+    # Get the available array data dataframe.
+    array_dataframe = pd.DataFrame(
+        glob(op.join(data_dir, f"*{file_extension}")), columns=[constants.path_column_name]
+    )
+
+    # The control population has a different format for the path column.
+    if is_control_population:
+        array_dataframe["name"] = array_dataframe[constants.path_column_name].apply(
+            lambda x: op.splitext(op.basename(x))[0]
+        )
+        dataframe["name"] = dataframe[constants.path_column_name].apply(lambda x: op.splitext(op.basename(x))[0])
+        dataframe = dataframe.merge(array_dataframe, on="name")
+        dataframe.drop(columns=["name"], inplace=True)
+
+    else:
+        dataframe[constants.path_column_name] = dataframe.apply(
+            lambda row: op.join(
+                data_dir,
+                f"{row[constants.filename_column_name]}_{row[constants.run_number_column_name]}{file_extension}",
+            ),
+            axis=1,
+        )
+        # Replace \\ with / to avoid path issues.
+        dataframe[constants.path_column_name] = dataframe[constants.path_column_name].apply(
+            lambda x: x.replace('\\', '/')
+        )
+        array_dataframe[constants.path_column_name] = array_dataframe[constants.path_column_name].apply(
+            lambda x: x.replace('\\', '/')
+        )
+        # Merge with the available images.
+        dataframe = dataframe.merge(array_dataframe, on=constants.path_column_name)
+
+    # Rename columns.
+    dataframe.rename(columns=constants.COLUMN_RENAME_MAP, inplace=True)
+
+    # Scale age column if it is in the dataframe.
+    if constants.age_column_name in dataframe.columns:
+        dataframe[constants.age_column_name] = dataframe[constants.age_column_name] / 100
+        dataframe[constants.age_column_name] = dataframe[constants.age_column_name].astype(float)
+
+    # Categorize LVEF.
+    # Also return the LVEF_40 column if return_lvef_40_column is True.
+    if return_lvef_40_column:
+        dataframe[constants.lvef_40_column_name] = dataframe[constants.lvef_label_column_name].apply(
+            lambda lvef: categorize_lvef(lvef, 40)
+        )
+
+    dataframe[constants.lvef_label_column_name] = dataframe[constants.lvef_label_column_name].apply(
+        lambda lvef: categorize_lvef(lvef, lvef_threshold)
+    )
+
+    if imputer_dir:
+        import joblib
+
+        imputer = joblib.load(op.join(imputer_dir, "imputer.joblib"))
+        threshold_dict = joblib.load(op.join(imputer_dir, "imputer_threshold_dict.joblib"))
+
+        clinical_feature_columns = constants.numerical_feature_column_names + constants.categorical_feature_column_names
+        # Mark all imputed values as np.nan so that they can be imputed by the imputer.
+        dataframe.loc[dataframe[constants.impute_column_name] == True, constants.imputed_feature_column_names] = np.nan
+        # Impute the missing values.
+        dataframe[clinical_feature_columns] = imputer.transform(dataframe[clinical_feature_columns])
+        # Apply the thresholds to the imputed values so that they are either 0 or 1.
+        dataframe = apply_thresholds(dataframe, threshold_dict)
+
+    # Generate split column.
+    if do_split:
+        if "split" not in dataframe.columns:
+            dataframe = dataframe.apply(get_split_by_year, axis=1)
     return dataframe

--- a/notebooks/evaluation_1d.ipynb
+++ b/notebooks/evaluation_1d.ipynb
@@ -1,0 +1,1104 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## **Preparations**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "c:\\Anaconda3\\envs\\ecg\\lib\\site-packages\\numpy\\_distributor_init.py:30: UserWarning: loaded more than 1 DLL from .libs:\n",
+      "c:\\Anaconda3\\envs\\ecg\\lib\\site-packages\\numpy\\.libs\\libopenblas.FB5AE2TYXYH2IJRDKGDGQ3XBKLKTF43H.gfortran-win_amd64.dll\n",
+      "c:\\Anaconda3\\envs\\ecg\\lib\\site-packages\\numpy\\.libs\\libopenblas64__v0.3.21-gcc_10_3_0.dll\n",
+      "  warnings.warn(\"loaded more than 1 DLL from .libs:\"\n",
+      "c:\\Anaconda3\\envs\\ecg\\lib\\site-packages\\pkg_resources\\__init__.py:123: PkgResourcesDeprecationWarning: llow is an invalid version and will not be supported in a future release\n",
+      "  warnings.warn(\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "import sys\n",
+    "import os.path as op\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "from tqdm.auto import tqdm\n",
+    "from functools import partial\n",
+    "\n",
+    "import torch\n",
+    "\n",
+    "sys.path.append(\"..\")\n",
+    "from mtecg.classifier import ECGClassifier\n",
+    "from mtecg.evaluation import evaluate_from_dataframe_1d\n",
+    "from mtecg.utils import load_ecg_dataframe_1d\n",
+    "import mtecg.constants as constants\n",
+    "\n",
+    "\n",
+    "SEED = 42\n",
+    "np.random.seed(SEED)\n",
+    "torch.manual_seed(SEED)\n",
+    "torch.backends.cudnn.deterministic = True\n",
+    "torch.backends.cudnn.benchmark = False\n",
+    "torch.cuda.manual_seed(SEED)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "device = \"cuda\"\n",
+    "round_probabilities = False\n",
+    "\n",
+    "singletask_scar_model_path = \"../trained_models/1d/single-task-scar/resnet34d_200\"\n",
+    "singletask_lvef_model_path = \"../trained_models/1d/single-task-lvef/resnet34d_200_LVEF50\"\n",
+    "multitask_model_path = \"../trained_models/1d/multi-task/resnet34d_200_LVEF50\"\n",
+    "multitask_old_format_model_path = \"../trained_models/1d/multi-task-old-format/resnet34d_200_LVEF50\"\n",
+    "multitask_transferred_model_path = \"../trained_models/1d/multi-task-transferred/resnet34d_200_LVEF50\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "singletask_scar_classifier = ECGClassifier(\n",
+    "    singletask_scar_model_path,\n",
+    "    model_class=\"single-task-1d\",\n",
+    "    device=device,\n",
+    "    task=\"scar\",\n",
+    "    round_probabilities=round_probabilities,\n",
+    ")\n",
+    "singletask_lvef_classifier = ECGClassifier(\n",
+    "    singletask_lvef_model_path,\n",
+    "    model_class=\"single-task-1d\",\n",
+    "    device=device,\n",
+    "    task=\"lvef\",\n",
+    "    round_probabilities=round_probabilities,\n",
+    ")\n",
+    "\n",
+    "multitask_classifier = ECGClassifier(\n",
+    "    multitask_model_path, model_class=\"multi-task-1d\", device=device, round_probabilities=round_probabilities\n",
+    ")\n",
+    "multitask_old_format_classifier = ECGClassifier(\n",
+    "    multitask_old_format_model_path, model_class=\"multi-task-1d\", device=device, round_probabilities=round_probabilities\n",
+    ")\n",
+    "multitask_transferred_classifier = ECGClassifier(\n",
+    "    multitask_transferred_model_path, model_class=\"multi-task-1d\", device=device, round_probabilities=round_probabilities\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "old_csv_path = \"../datasets/all_ECG_cleared_duplicate_may23_final_1d_labels_with_rpeaks.csv\"\n",
+    "old_data_dir = \"../datasets/siriraj_data/ECG_MRI_1d_data_interp\"\n",
+    "new_csv_path = \"../datasets/all_ECG_cleared_duplicate_may23_final_1d_labels_with_rpeaks.csv\"\n",
+    "new_data_dir = \"../datasets/siriraj_data/ECG_MRI_1d_data_interp\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Old test set.\n",
+    "old_test_df = load_ecg_dataframe_1d(\n",
+    "    old_csv_path,\n",
+    "    old_data_dir,\n",
+    "    # imputer_dir=multitask_clinical_model_path,\n",
+    "    do_split=True\n",
+    ")\n",
+    "old_test_df = old_test_df[old_test_df[\"split\"] == \"old_test\"].reset_index(drop=True)\n",
+    "\n",
+    "# New test set. No need to impute.\n",
+    "new_test_df = load_ecg_dataframe_1d(\n",
+    "    new_csv_path,\n",
+    "    new_data_dir,\n",
+    "    # imputer_dir=multitask_clinical_model_path,\n",
+    "    do_split=True,\n",
+    ")\n",
+    "\n",
+    "new_test_df = new_test_df[new_test_df[\"split\"] == \"new_test\"].reset_index(drop=True)\n",
+    "\n",
+    "# New test set with lvef_threshold= 40. No need to impute.\n",
+    "sensitivity_new_test_df = load_ecg_dataframe_1d(\n",
+    "    new_csv_path,\n",
+    "    new_data_dir,\n",
+    "    # imputer_dir=multitask_clinical_model_path,\n",
+    "    do_split=False,\n",
+    "    lvef_threshold=40,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "56f8315a4ea14b789fba8d05c5740cb0",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/895 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c4dfab0d29dc4fc38c5c1f49c27175b1",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/895 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Shape Before filter out: (895, 35)\n",
+      "Shape After filter out: (895, 35)\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e9f36066e3994fe1bfcafb51c170935a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/895 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b5baed7f5ad2447580ad0cc17c54ca80",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/895 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Shape After filter out: (895, 35)\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "fe5fb1e887a74f30a76dcc4c7a3d9d58",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/895 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d325cfd546d6436196e5e7eb5238ca1a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/1264 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "13142988f96a4c2d96f8a166e5c165b6",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/1264 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Shape Before filter out: (1264, 35)\n",
+      "Shape After filter out: (1264, 35)\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "fccb3bca022847c0b4d63a846ec0fe76",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/1264 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "cd5d6f308f4544fbb4107e50075b8cac",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/1264 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Shape After filter out: (1263, 35)\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5ff033affd3e49d1a369bacf83cfa454",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/1263 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import pickle\n",
+    "from scipy.signal import resample\n",
+    "import biosppy\n",
+    "from tqdm.auto import tqdm\n",
+    "tqdm.pandas()\n",
+    "\n",
+    "ECG_FORMAT_TO_PAPER_PIXEL_SAMPLE_RATE = {\n",
+    "    'old': 294,\n",
+    "    'new': 280\n",
+    "}\n",
+    "\n",
+    "def apply_rpeaks_normalization(lead_array_list, rpeak_index, ecg_format):\n",
+    "    paper_pixel_sample_rate = ECG_FORMAT_TO_PAPER_PIXEL_SAMPLE_RATE[ecg_format]\n",
+    "    start = max(0, int(rpeak_index - 0.5 * paper_pixel_sample_rate))\n",
+    "    end = int(rpeak_index + 1.5 * paper_pixel_sample_rate)\n",
+    "    return [lead[start:end] for lead in lead_array_list]\n",
+    "\n",
+    "def has_empty_leads(lead_array_list):\n",
+    "    for lead in lead_array_list:\n",
+    "        if len(lead) == 0:\n",
+    "            return True\n",
+    "    return False\n",
+    "\n",
+    "def filter_out_empty_leads(dataframe):\n",
+    "    print(f\"Shape Before filter out: {dataframe.shape}\")\n",
+    "    dataframe['has_empty_leads'] = dataframe['lead_arrays'].progress_apply(lambda lead_list: has_empty_leads(lead_list))\n",
+    "    dataframe = dataframe[dataframe['has_empty_leads'] != True].reset_index(drop=True)\n",
+    "    print(f\"Shape After filter out: {dataframe.shape}\")\n",
+    "    return dataframe\n",
+    "\n",
+    "def resample_leads(lead_array_list, sample_rate: int = 200):\n",
+    "    for i, lead in enumerate(lead_array_list):\n",
+    "        try:\n",
+    "            lead_array_list[i] = resample(lead, sample_rate)\n",
+    "        except:\n",
+    "            print(f\"Error resampling lead {i}\")\n",
+    "            print(lead)\n",
+    "            print(len(lead))\n",
+    "\n",
+    "    return lead_array_list\n",
+    "\n",
+    "def process_dataframe(dataframe, sample_rate: int = 200):\n",
+    "    dataframe['lead_arrays'] = dataframe[constants.path_column_name].progress_apply(lambda x: pickle.load(open(x, \"rb\")))\n",
+    "    dataframe['has_empty_leads'] = dataframe['lead_arrays'].progress_apply(lambda lead_list: has_empty_leads(lead_list))\n",
+    "    print(f\"Shape Before filter out: {dataframe.shape}\")\n",
+    "    dataframe = dataframe[dataframe['has_empty_leads'] != True].reset_index(drop=True)\n",
+    "    print(f\"Shape After filter out: {dataframe.shape}\")\n",
+    "    dataframe['lead_arrays'] = dataframe.progress_apply(lambda row: apply_rpeaks_normalization(row['lead_arrays'], row['median_first_rpeak_index'], row['ecg_format']), axis=1)\n",
+    "    dataframe['has_empty_leads'] = dataframe['lead_arrays'].progress_apply(lambda lead_list: has_empty_leads(lead_list))\n",
+    "    dataframe = dataframe[dataframe['has_empty_leads'] != True].reset_index(drop=True)\n",
+    "    print(f\"Shape After filter out: {dataframe.shape}\")\n",
+    "    dataframe['lead_arrays'] = dataframe['lead_arrays'].progress_apply(lambda lead_list: resample_leads(lead_list, sample_rate))\n",
+    "    return dataframe\n",
+    "\n",
+    "old_test_df = process_dataframe(old_test_df, 200)\n",
+    "new_test_df = process_dataframe(new_test_df, 200)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# from mtecg.datasets_1d import ECG1DDataset\n",
+    "# from torch.utils.data import DataLoader\n",
+    "\n",
+    "# dataset = ECG1DDataset(\n",
+    "#     dataframe=old_test_df,\n",
+    "#     label_column=\"scar_cad\",\n",
+    "# )\n",
+    "# dataloader = DataLoader(dataset, batch_size=4, shuffle=False)\n",
+    "\n",
+    "# dataloader_iter = iter(dataloader)\n",
+    "\n",
+    "# for i in range(1):\n",
+    "#     data = next(dataloader_iter)\n",
+    "#     print(data[0].shape)\n",
+    "#     print(data[1].shape)\n",
+    "\n",
+    "\n",
+    "# leads_batch = data[0]\n",
+    "# batch_size = leads_batch.shape[0]\n",
+    "# leads_batch = leads_batch.view(batch_size * 12, 1, -1)\n",
+    "# leads_batch = leads_batch.unsqueeze(1)\n",
+    "# leads_batch.shape\n",
+    "\n",
+    "\n",
+    "# model = singletask_scar_classifier.model\n",
+    "# lead_embeddings = model.model(leads_batch.to(device))\n",
+    "\n",
+    "# lead_embeddings = lead_embeddings.view(batch_size, 12, -1)\n",
+    "# lead_embeddings.shape\n",
+    "# torch.mean(lead_embeddings, dim=1).shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# For convenience.\n",
+    "\n",
+    "EVAL_DATA_MAP = {\n",
+    "    \"old-test\": {\"data\": old_test_df, \"save_suffix\": \"old_test\",},\n",
+    "    # \"old-test-sensitivity\": {\"data\": sensitivity_old_test_df, \"save_suffix\": \"old_test_sensitivity\",},\n",
+    "    \"new-test\": {\"data\": new_test_df, \"save_suffix\": \"new_test\",},\n",
+    "    # \"new-test-sensitivity\": {\"data\": sensitivity_new_test_df, \"save_suffix\": \"new_test_sensitivity\",},\n",
+    "    # \"control-test\": {\"data\": control_test_df, \"save_suffix\": \"control_test\",},\n",
+    "}\n",
+    "\n",
+    "TEST_SET_SAVE_SUFFIX_LIST = [param_dict[\"save_suffix\"] for param_dict in EVAL_DATA_MAP.values()]\n",
+    "\n",
+    "\n",
+    "def evaluate_and_save(\n",
+    "    classifier: ECGClassifier,\n",
+    "    save_dir: str,\n",
+    "    average: str = \"weighted\",\n",
+    "    prediction_csv_name_pattern: str = \"prediction_{save_suffix}.csv\",\n",
+    "    metric_csv_name_pattern: str = \"metrics_{save_suffix}.csv\",\n",
+    "):\n",
+    "    for test_set_name, param_dict in tqdm(EVAL_DATA_MAP.items()):\n",
+    "        dataframe, save_suffix = param_dict[\"data\"], param_dict[\"save_suffix\"]\n",
+    "        if \"control\" in test_set_name:\n",
+    "            result_dataframe, metric_dataframe = evaluate_from_dataframe_1d(\n",
+    "                dataframe,\n",
+    "                classifier,\n",
+    "                is_control_population=True,\n",
+    "                average=average,\n",
+    "                )\n",
+    "        else:\n",
+    "            result_dataframe, metric_dataframe = evaluate_from_dataframe_1d(dataframe, classifier)\n",
+    "\n",
+    "        result_save_path = op.join(save_dir, prediction_csv_name_pattern.format(save_suffix=save_suffix))\n",
+    "        metric_save_path = op.join(save_dir, metric_csv_name_pattern.format(save_suffix=save_suffix))\n",
+    "\n",
+    "        result_dataframe.to_csv(result_save_path, index=False)\n",
+    "        metric_dataframe.to_csv(metric_save_path, index=True)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## **Evaluation**"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### **Baseline**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn.metrics import confusion_matrix, accuracy_score, f1_score, roc_auc_score\n",
+    "\n",
+    "def get_baseline_metrics(\n",
+    "    save_dir: str = None,\n",
+    "    label_column_name: str = \"scar_cad\",\n",
+    "    metric_csv_name_pattern: str = \"{save_suffix}.csv\",\n",
+    "    average: str = \"weighted\",\n",
+    "    ):\n",
+    "    baseline_metric_dict = {}\n",
+    "    for test_set_name, param_dict in EVAL_DATA_MAP.items():\n",
+    "        if \"control\" in test_set_name:\n",
+    "            continue\n",
+    "        dataframe = param_dict[\"data\"]\n",
+    "        baseline_predictions = np.zeros(len(dataframe))\n",
+    "\n",
+    "        # get specificity from confusion matrix\n",
+    "        tn, fp, fn, tp = confusion_matrix(dataframe[label_column_name], baseline_predictions).ravel()\n",
+    "        specificity = tn / (tn+fp)\n",
+    "        fpr = fp / (fp+tn)\n",
+    "\n",
+    "        baseline_metric_dict[test_set_name] = {\n",
+    "            \"Accuracy\": accuracy_score(dataframe[label_column_name], baseline_predictions),\n",
+    "            \"Sensitivity\": None,\n",
+    "            \"Specificity\": specificity,\n",
+    "            \"F1\": f1_score(dataframe[label_column_name], baseline_predictions, average=average),\n",
+    "            \"AUC\": None,\n",
+    "            \"FPR\": fpr,\n",
+    "            \"FNR\": None,\n",
+    "        }\n",
+    "\n",
+    "    if save_dir:\n",
+    "        os.makedirs(save_dir, exist_ok=True)\n",
+    "        for test_set_name, param_dict in EVAL_DATA_MAP.items():\n",
+    "            if \"control\" in test_set_name:\n",
+    "                continue\n",
+    "            save_suffix = param_dict[\"save_suffix\"]\n",
+    "            metric_save_path = op.join(save_dir, metric_csv_name_pattern.format(save_suffix=save_suffix))\n",
+    "            pd.DataFrame(baseline_metric_dict[test_set_name], index=[0]).T.to_csv(metric_save_path, index=True)\n",
+    "\n",
+    "    return baseline_metric_dict"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scar_baseline_metric_dict = get_baseline_metrics(\n",
+    "    save_dir=op.join(\"../resources/statistics/1d/scar_baseline_metrics\"),\n",
+    "    label_column_name=\"scar_cad\",\n",
+    ")\n",
+    "\n",
+    "lvef_baseline_metric_dict = get_baseline_metrics(\n",
+    "    save_dir=op.join(\"../resources/statistics/1d/lvef_baseline_metrics\"),\n",
+    "    label_column_name=\"lvef\",\n",
+    ")"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### **single-task**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "4350863edddd4b6c899ac1330c2b0751",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/2 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "aaab9c706b614b298869e281cbe3d615",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "0it [00:00, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "40ee2ab661f44e00978bbb9ef175b22d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "0it [00:00, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "evaluate_and_save(singletask_scar_classifier, save_dir=singletask_scar_model_path)\n",
+    "# evaluate_and_save(singletask_lvef_classifier, save_dir=singletask_lvef_model_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(0    722\n",
+       " 1    173\n",
+       " Name: lvef_label, dtype: int64,\n",
+       " 0    611\n",
+       " 1    284\n",
+       " Name: lvef_prediction, dtype: int64)"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "prediction_df = pd.read_csv(op.join(singletask_lvef_model_path, \"prediction_old_test.csv\"))\n",
+    "prediction_df.lvef_label.value_counts(), prediction_df.lvef_prediction.value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(0    1035\n",
+       " 1     228\n",
+       " Name: lvef_label, dtype: int64,\n",
+       " 0    1018\n",
+       " 1     245\n",
+       " Name: lvef_prediction, dtype: int64)"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "prediction_df = pd.read_csv(op.join(singletask_lvef_model_path, \"prediction_new_test.csv\"))\n",
+    "prediction_df.lvef_label.value_counts(), prediction_df.lvef_prediction.value_counts()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### **single-task-clinical**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "evaluate_and_save(singletask_scar_clinical_classifier, save_dir=singletask_scar_clinical_model_path)\n",
+    "evaluate_and_save(singletask_lvef_clinical_classifier, save_dir=singletask_lvef_clinical_model_path)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### **multi-task**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "71383f659ecf4a1ab229f8ec11778c7e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/2 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5ec2842b13fa4b91a5bd59289f34a4ac",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "0it [00:00, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f568112122324d669e5123d0620624d3",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "0it [00:00, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "evaluate_and_save(multitask_classifier, save_dir=multitask_model_path)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**multi-task-old-format**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8bea4d89cf814066a225ec726569594d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/2 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e861c6d7f1d049a2b620f00d62fb4910",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "0it [00:00, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "269d4aae41ed40d7a9702e5c1248d744",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "0it [00:00, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "evaluate_and_save(multitask_old_format_classifier, save_dir=multitask_old_format_model_path)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**multi-task-transferred**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f7262d4013f0433cb21b6ac3ad7c462a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/2 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7504e54c5e2e43bd9b4d120798eb0152",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "0it [00:00, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "90ff5f6fa17843ceb7689c38a1ecc12f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "0it [00:00, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "evaluate_and_save(multitask_transferred_classifier, save_dir=multitask_transferred_model_path)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### **multi-task-clinical**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Overwrite the EVAL_DATA_MAP to only evaluate the test sets with available clinical data.\n",
+    "EVAL_DATA_MAP = {\n",
+    "    \"old-test\": {\"data\": old_test_df, \"save_suffix\": \"old_test\",},\n",
+    "    \"old-test-sensitivity\": {\"data\": sensitivity_old_test_df, \"save_suffix\": \"old_test_sensitivity\",},\n",
+    "    \"new-test\": {\"data\": new_test_df, \"save_suffix\": \"new_test\",},\n",
+    "    \"new-test-sensitivity\": {\"data\": sensitivity_new_test_df, \"save_suffix\": \"new_test_sensitivity\",},\n",
+    "}\n",
+    "\n",
+    "evaluate_and_save(multitask_clinical_classifier, save_dir=multitask_clinical_model_path)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[scar] Prevalence-specific Evaluation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import random\n",
+    "\n",
+    "def sample(dataframe, num_samples: int = 500, prevalence: float = 7.9):\n",
+    "    \"\"\"\n",
+    "    Sample a dataframe to a prevalence of 7.9% (the prevalence of scar in the dataset).\n",
+    "    \"\"\"\n",
+    "    positive_dataframe = dataframe[dataframe.scar_label == 1].reset_index(drop=True).copy()\n",
+    "    negative_dataframe = dataframe[dataframe.scar_label == 0].reset_index(drop=True).copy()\n",
+    "    \n",
+    "    num_positive_samples = int(num_samples * prevalence / 100)\n",
+    "    num_negative_samples = num_samples - num_positive_samples\n",
+    "    \n",
+    "    random_state = random.randint(0, 1000)\n",
+    "    positive_sample_dataframe = positive_dataframe.sample(n=num_positive_samples, random_state = random_state).reset_index(drop=True)\n",
+    "    negative_sample_dataframe = negative_dataframe.sample(n=num_negative_samples, random_state = random_state).reset_index(drop=True)\n",
+    "    sampled_dataframe = pd.concat([positive_sample_dataframe, negative_sample_dataframe]).reset_index(drop=True)\n",
+    "    return sampled_dataframe"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import scipy.stats as st\n",
+    "from mtecg.evaluation import calculate_metrics\n",
+    "\n",
+    "num_sample_per_iteration = 500\n",
+    "# num_iteration_list = [20, 50, 200]\n",
+    "num_iteration_list = [1000]\n",
+    "\n",
+    "\n",
+    "multitask_prediction_df = pd.read_csv(op.join(multitask_model_path, \"prediction_new_test.csv\"))\n",
+    "\n",
+    "for num_iteration in tqdm(num_iteration_list):\n",
+    "    scar_auc_list = []\n",
+    "    scar_f1_list = []\n",
+    "    for i in tqdm(range(num_iteration)):\n",
+    "        sampled_test_df = sample(multitask_prediction_df, num_samples = num_sample_per_iteration)\n",
+    "        metric_df = calculate_metrics(sampled_test_df, tasks=[\"scar\"])\n",
+    "        # _, metric_df = evaluate_from_dataframe(sampled_test_df, multitask_classifier)\n",
+    "        # _, metric_df = evaluate_from_dataframe(sampled_clinical_test_df, multitask_clinical_classifier)\n",
+    "        scar_auc_list.append(metric_df.T[\"AUC\"][0])\n",
+    "        scar_f1_list.append(metric_df.T[\"F1\"][0])\n",
+    "\n",
+    "    # Create 95% confidence interval for population mean scar auc.\n",
+    "    auc_confidence_interval_tuple = st.t.interval(\n",
+    "        alpha=0.95,\n",
+    "        df=len(scar_auc_list)-1,\n",
+    "        loc=np.mean(scar_auc_list),\n",
+    "        scale=st.sem(scar_auc_list)\n",
+    "        )\n",
+    "    \n",
+    "    f1_confidence_interval_tuple = st.t.interval(\n",
+    "        alpha=0.95,\n",
+    "        df=len(scar_f1_list)-1,\n",
+    "        loc=np.mean(scar_f1_list),\n",
+    "        scale=st.sem(scar_f1_list)\n",
+    "        )\n",
+    "\n",
+    "    auc_summary_df = pd.DataFrame(\n",
+    "        { \n",
+    "            \"mean\": [np.mean(scar_auc_list)],\n",
+    "            \"std\": [np.std(scar_auc_list)],\n",
+    "            \"lower_bound_ci\": [auc_confidence_interval_tuple[0]],\n",
+    "            \"upper_bound_ci\": [auc_confidence_interval_tuple[1]],\n",
+    "            }\n",
+    "    )\\\n",
+    "        .round(4)\n",
+    "\n",
+    "    f1_summary_df = pd.DataFrame(\n",
+    "        { \n",
+    "            \"mean\": [np.mean(scar_f1_list)],\n",
+    "            \"std\": [np.std(scar_f1_list)],\n",
+    "            \"lower_bound_ci\": [f1_confidence_interval_tuple[0]],\n",
+    "            \"upper_bound_ci\": [f1_confidence_interval_tuple[1]],\n",
+    "            }\n",
+    "    )\\\n",
+    "        .round(4)\n",
+    "\n",
+    "    auc_summary_df.to_csv(op.join(multitask_model_path, f\"prevalence_specific_auc_{num_sample_per_iteration}_{num_iteration}.csv\"), index=False)\n",
+    "    f1_summary_df.to_csv(op.join(multitask_model_path, f\"prevalence_specific_f1_{num_sample_per_iteration}_{num_iteration}.csv\"), index=False)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## **Save Prediction Probabilities on Each Test Set as a single file**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from typing import Dict, List\n",
+    "\n",
+    "# A function to read the predictions from the save csv file in each model folder.\n",
+    "# The probability columns of each task are then concatenated into a single dataframe.\n",
+    "# The probability columns are in the format f\"{task}_probability\".\n",
+    "\n",
+    "def get_probabilities(\n",
+    "    model_name_to_dir_map: Dict[str, str],\n",
+    "    test_set_suffix_list: List[str],\n",
+    "    probability_column_name_pattern: str = \"{task}_probability\",\n",
+    "    prediction_csv_name_pattern: str = \"prediction_{test_set_suffix}.csv\",\n",
+    "    task: str = \"scar\",\n",
+    ") -> List[pd.DataFrame]:\n",
+    "    \"\"\"\n",
+    "    Get the probabilities of the given task from the predictions of the models.\n",
+    "    \"\"\"\n",
+    "    probability_column_name = probability_column_name_pattern.format(task=task)\n",
+    "\n",
+    "    test_set_to_probability_dataframe_dict = {}\n",
+    "    for test_set_suffix in test_set_suffix_list:\n",
+    "        if \"control\" in test_set_suffix:\n",
+    "            continue\n",
+    "        model_name_to_probabilities_dict = {}\n",
+    "        for model_name, model_dir in model_name_to_dir_map.items():\n",
+    "            filename = prediction_csv_name_pattern.format(test_set_suffix=test_set_suffix)\n",
+    "            prediction_path = op.join(model_dir, filename)\n",
+    "            prediction_dataframe = pd.read_csv(prediction_path)\n",
+    "            if \"true_label\" not in model_name_to_probabilities_dict.keys():\n",
+    "                model_name_to_probabilities_dict[\"true_label\"] = prediction_dataframe[f\"{task}_label\"]\n",
+    "            model_name_to_probabilities_dict[model_name] = prediction_dataframe[probability_column_name]\n",
+    "        probability_dataframe = pd.DataFrame(model_name_to_probabilities_dict)\n",
+    "        test_set_to_probability_dataframe_dict[test_set_suffix] = probability_dataframe\n",
+    "    return test_set_to_probability_dataframe_dict"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "singletask_scar_model_path = \"../trained_models/1d/single-task-scar/resnet34d_200\"\n",
+    "singletask_lvef_model_path = \"../trained_models/1d/single-task-lvef/resnet34d_200_LVEF50\"\n",
+    "multitask_model_path = \"../trained_models/1d/multi-task/resnet34d_200_LVEF50\"\n",
+    "multitask_old_format_model_path = \"../trained_models/1d/multi-task-old-format/resnet34d_200_LVEF50\"\n",
+    "multitask_transferred_model_path = \"../trained_models/1d/multi-task-transferred/resnet34d_200_LVEF50\"\n",
+    "\n",
+    "probability_save_dir = \"../resources/prediction_probabilities_1d\"\n",
+    "os.makedirs(probability_save_dir, exist_ok=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tasks = [\"scar\", \"lvef\"]\n",
+    "for task in tasks:\n",
+    "    model_name_to_dir_map = {\n",
+    "        \"multi-task-old-format\": multitask_old_format_model_path,\n",
+    "        \"multi-task-transferred\": multitask_transferred_model_path,\n",
+    "        \"single-task\": singletask_scar_model_path if task == \"scar\" else singletask_lvef_model_path,\n",
+    "        \"multi-task\": multitask_model_path,\n",
+    "    }\n",
+    "\n",
+    "    test_set_to_probability_dataframe_dict = get_probabilities(\n",
+    "        model_name_to_dir_map=model_name_to_dir_map,\n",
+    "        test_set_suffix_list=TEST_SET_SAVE_SUFFIX_LIST,\n",
+    "        task=task,\n",
+    "    )\n",
+    "\n",
+    "    for test_set_suffix, probability_dataframe in test_set_to_probability_dataframe_dict.items():\n",
+    "        probability_save_path = op.join(probability_save_dir, f\"{task}_probabilities_{test_set_suffix}.csv\")\n",
+    "        probability_dataframe.to_csv(probability_save_path, index=False)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "ecg",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.13"
+  },
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "109b74d06ceef90c267188b655f808679842e5df9d924ed4ca45afc3047e2ff5"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/scripts/configs-1d/multi-task-old-format.json
+++ b/scripts/configs-1d/multi-task-old-format.json
@@ -1,0 +1,25 @@
+{
+	"model_type": "multi-task-1d",
+	"dataset": "pretrain",
+	"parent_save_dir": "../trained_models/1d/multi-task-old-format",
+	"sample_rate": 200,
+	"lvef_threshold": 50,
+	"num_epochs": 30,
+	"batch_size": 16,
+	"accumulate_grad_batches": 1,
+	"in_channels": 3,
+	"learning_rate": 5e-3,
+	"use_timm": true,
+	"pretrained": true,
+	"backbone": "resnet34d",
+	"latent_dim": 512,
+	"scar_class": 2,
+	"lvef_class": 2,
+	"scar_lvef_loss_ratio": [
+		0.7,
+		0.3
+	],
+	"bias_head": true,
+	"device": "cuda",
+	"num_workers": 0
+}

--- a/scripts/configs-1d/multi-task-transferred.json
+++ b/scripts/configs-1d/multi-task-transferred.json
@@ -1,0 +1,26 @@
+{
+	"model_type": "multi-task-1d",
+	"dataset": "transfer",
+	"parent_save_dir": "../trained_models/1d/multi-task-transferred",
+	"pretrained_model_path": "../trained_models/1d/multi-task-old-format/resnet34d_200_LVEF50",
+	"sample_rate": 200,
+	"lvef_threshold": 50,
+	"num_epochs": 30,
+	"batch_size": 16,
+	"accumulate_grad_batches": 1,
+	"in_channels": 3,
+	"learning_rate": 5e-3,
+	"use_timm": true,
+	"pretrained": true,
+	"backbone": "resnet34d",
+	"latent_dim": 512,
+	"scar_class": 2,
+	"lvef_class": 2,
+	"scar_lvef_loss_ratio": [
+		0.7,
+		0.3
+	],
+	"bias_head": true,
+	"device": "cuda",
+	"num_workers": 0
+}

--- a/scripts/configs-1d/multi-task.json
+++ b/scripts/configs-1d/multi-task.json
@@ -1,0 +1,25 @@
+{
+	"model_type": "multi-task-1d",
+	"dataset": "all",
+	"parent_save_dir": "../trained_models/1d/multi-task",
+	"sample_rate": 200,
+	"lvef_threshold": 50,
+	"num_epochs": 30,
+	"batch_size": 16,
+	"accumulate_grad_batches": 1,
+	"in_channels": 3,
+	"learning_rate": 5e-3,
+	"use_timm": true,
+	"pretrained": true,
+	"backbone": "resnet34d",
+	"latent_dim": 512,
+	"scar_class": 2,
+	"lvef_class": 2,
+	"scar_lvef_loss_ratio": [
+		0.7,
+		0.3
+	],
+	"bias_head": true,
+	"device": "cuda",
+	"num_workers": 0
+}

--- a/scripts/configs-1d/single-task-lvef.json
+++ b/scripts/configs-1d/single-task-lvef.json
@@ -1,0 +1,20 @@
+{
+	"model_type": "single-task-1d",
+	"dataset": "all",
+	"task": "lvef",
+	"parent_save_dir": "../trained_models/1d/single-task-lvef",
+	"sample_rate": 200,
+	"lvef_threshold": 50,
+	"num_epochs": 30,
+	"batch_size": 16,
+	"accumulate_grad_batches": 1,
+	"in_channels": 3,
+	"learning_rate": 5e-3,
+	"use_timm": true,
+	"pretrained": true,
+	"backbone": "resnet34d",
+	"latent_dim": 512,
+	"bias_head": true,
+	"device": "cuda",
+	"num_workers": 0
+}

--- a/scripts/configs-1d/single-task-scar.json
+++ b/scripts/configs-1d/single-task-scar.json
@@ -1,0 +1,19 @@
+{
+	"model_type": "single-task-1d",
+	"dataset": "all",
+	"task": "scar",
+	"parent_save_dir": "../trained_models/1d/single-task-scar",
+	"sample_rate": 200,
+	"num_epochs": 30,
+	"batch_size": 16,
+	"accumulate_grad_batches": 1,
+	"in_channels": 3,
+	"learning_rate": 5e-3,
+	"use_timm": true,
+	"pretrained": true,
+	"backbone": "resnet34d",
+	"latent_dim": 512,
+	"bias_head": true,
+	"device": "cuda",
+	"num_workers": 0
+}

--- a/scripts/preprocess_data_1d.py
+++ b/scripts/preprocess_data_1d.py
@@ -1,0 +1,270 @@
+import os
+import sys
+import os.path as op
+import numpy as np
+from glob import glob
+import pandas as pd
+from argparse import ArgumentParser
+import pickle
+from typing import List, Tuple
+from tqdm.auto import tqdm
+from PIL import Image, ImageOps, ImageDraw
+
+module_dir = op.join(op.dirname(op.abspath(__file__)), "..")
+sys.path.append(module_dir)
+from mtecg import *
+from scripts.preprocess_data import fix_duplicated_save_paths
+
+## Position of ECG Leads
+RAW_NUMBER_POSIX_OLD_FORMAT = {
+    "I": [(29, 56), (8, 26)],
+    "II": [(37, 275), (12, 249)],
+    "III": [(50, 500), (14, 468)],
+    "aVR": [(98, 721), (9, 686)],
+    "aVL": [(92, 942), (7, 901)],
+    "aVF": [(87, 1163), (10, 1122)],
+    "V1": [(1539, 58), (1480, 21)],
+    "V2": [(1536, 279), (1481, 247)],
+    "V3": [(1532, 496), (1483, 469)],
+    "V4": [(1536, 717), (1480, 679)],
+    "V5": [(1534, 941), (1482, 908)],
+    "V6": [(1533, 1163), (1483, 1125)],
+}
+
+RAW_NUMBER_POSIX_NEW_FORMAT = {
+    "I": [(33, 77), (13, 46)],
+    "II": [(63, 431), (13, 400)],
+    "III": [(93, 785), (13, 754)],
+    "aVR": [(858, 77), (770, 46)],
+    "aVL": [(858, 431), (770, 400)],
+    "aVF": [(858, 785), (770, 754)],
+    "V1": [(1582, 77), (1525, 46)],
+    "V2": [(1582, 431), (1525, 400)],
+    "V3": [(1582, 785), (1525, 754)],
+    "V4": [(2341, 77), (2285, 46)],
+    "V5": [(2341, 431), (2285, 400)],
+    "V6": [(2341, 785), (2285, 754)],
+}
+
+ECG_FORMAT_TO_LEAD_X_SIZE = {"old": 1472, "new": 701}
+
+
+def remove_numbers(img: Image, posix_dict: dict):
+
+    """
+    mask numbers of leads with white rectangles
+    """
+    img_draw = ImageDraw.Draw(img)
+    for k, shape in posix_dict.items():
+        img_draw.rectangle(shape, fill="#FFFFFF", outline="#FFFFFF")
+
+    return img
+
+
+def list_of_all_leads(img_no_grid: Image.Image, ecg_format: str = "new"):
+    """
+    get all leads
+    """
+    if ecg_format == "old":
+        row_length = 240
+        row_starts = [0, 240, 480, 720, 960, 1080]
+        row_ends = [num + row_length for num in row_starts]
+        col_length = ECG_FORMAT_TO_LEAD_X_SIZE[ecg_format]
+        col_starts = [0, 1472]
+        col_ends = [num + col_length for num in col_starts]
+
+    elif ecg_format == "new":
+        row_length = 350
+        row_starts = [0, 350, 700]
+        row_ends = [num + row_length for num in row_starts]
+        col_length = ECG_FORMAT_TO_LEAD_X_SIZE[ecg_format]
+        col_starts = [0, 740, 1478, 2217]
+        col_ends = [num + col_length for num in col_starts]
+
+    leads = []
+    for col_start, col_end in zip(col_starts, col_ends):
+        for row_start, row_end in zip(row_starts, row_ends):
+            leads.append(img_no_grid.crop((col_start, row_start, col_end, row_end)))
+    return leads
+
+
+def get_signal(image: Image):
+    """
+    get signal from cleaned single lead ecg image
+    """
+
+    image = ImageOps.grayscale(image)
+    image_array = np.array(image)
+
+    cy, cx = np.where((image_array[:, :] >= 0) & (image_array[:, :] <= 2))
+
+    array_height = image_array.shape[0]
+    cy = array_height - cy
+
+    cx, cy = zip(*sorted(zip(cx, cy)))
+    return np.array([cx, cy])
+
+
+def extract_ecg_signal(
+    path: str,
+    ecg_format: str = "new",
+    dpi: int = 300,
+) -> Tuple[List[np.ndarray], List[Image.Image]]:
+    """
+    get list of ecg signal from path
+    """
+    if ecg_format == "old":
+        box = (176, 258, 3126, 1672)
+        posix_dict = RAW_NUMBER_POSIX_OLD_FORMAT
+
+    elif ecg_format == "new":
+        box = (82, 950, 3000, 2000)
+        posix_dict = RAW_NUMBER_POSIX_NEW_FORMAT
+
+    img = read_pdf_to_image(path, dpi=dpi, box=box)
+    img = remove_grid_robust(np.array(img), n_jitter=3)
+    img = remove_numbers(img, posix_dict)
+
+    lead_image_list = list_of_all_leads(img, ecg_format=ecg_format)
+    lead_array_coordinates_list = [get_signal(lead_image) for lead_image in lead_image_list]
+    return lead_array_coordinates_list, lead_image_list
+
+
+def get_path(
+    row,
+    parent_dir="./siriraj_data/ECG_MRI",
+):
+    """Get the full path to the source pdf file"""
+    if "train" in row["split"] or row["split"] == "old_valid" or row["split"] == "old_test":
+        row["path"] = op.join(
+            parent_dir,
+            "ECG_80_Training_dataset",
+            str(row["Year"]),
+            str(row["Month"]),
+            row["File_Name"] + ".pdf",
+        )
+    elif "valid" in row["split"]:
+        row["path"] = op.join(
+            parent_dir,
+            "ECG_10_Development_dataset",
+            str(row["Year"]),
+            str(row["Month"]),
+            row["File_Name"] + ".pdf",
+        )
+
+    elif row["split"] == "new_test":
+        row["path"] = op.join(
+            "../datasets/siriraj_data/ECG_MRI_10%_test",
+            str(row["Year"]),
+            str(row["Month"]),
+            row["File_Name"] + ".pdf",
+        )
+    return row
+
+
+def fill_gaps(x_coordinate_array, y_coordinate_array, ecg_format: str = "new"):
+    # x should be 0, 1, 2, ..., max(x)
+    # y should be interpolated values for the missing x values
+
+    temp_df = (
+        pd.DataFrame({"x": x_coordinate_array, "y": y_coordinate_array}).groupby("x").mean().reset_index().astype(int)
+    )
+    temp_df = (
+        temp_df.set_index("x")
+        .reindex(range(0, ECG_FORMAT_TO_LEAD_X_SIZE[ecg_format] + 1))
+        .reset_index()
+        .interpolate()
+        .fillna(method="bfill")
+        .astype(int)
+    )
+    x_array, y_array = zip(*temp_df.values)
+    return x_array, y_array
+
+
+def preprocess(row):
+    pdf_path = row["path"]
+    save_path = row["save_path"]
+    ecg_format = row["ecg_format"]
+
+    try:
+        lead_array_coordinates_list, lead_image_list = extract_ecg_signal(
+            pdf_path,
+            ecg_format=ecg_format,
+        )
+        x_coordinate_array_list = [lead_coordinates[0] for lead_coordinates in lead_array_coordinates_list]
+        y_coordinate_array_list = [lead_coordinates[1] for lead_coordinates in lead_array_coordinates_list]
+
+        clean_x_coordinates, clean_y_coordinates = [], []
+        for x_array, y_array in zip(x_coordinate_array_list, y_coordinate_array_list):
+            x_array, y_array = fill_gaps(x_array, y_array, ecg_format=ecg_format)
+            # plt.plot(x_array, y_array)
+            clean_x_coordinates.append(x_array)
+            clean_y_coordinates.append(y_array)
+
+        assert len(clean_x_coordinates) == 12
+        assert (
+            np.unique([len(x) for x in clean_x_coordinates]).shape[0] == 1
+        ), f"Different lengths of x coordinates {[len(x) for x in clean_x_coordinates]}"
+        for i, (x, y) in enumerate(zip(clean_x_coordinates, clean_y_coordinates)):
+            assert len(x) == len(y), f"Length of x and y do not match for lead {i}"
+            assert len(x) == len(set(x)), f"Duplicate x values for lead {i}"
+
+        with open(save_path, "wb") as f:
+            pickle.dump(clean_y_coordinates, f)
+
+        return True
+    except Exception as e:
+        print(f"Error in {pdf_path}")
+        print(e)
+        return pdf_path
+
+
+def main(args):
+    if not args.save_dir:
+        raise ValueError("Please specify the save directory")
+    os.makedirs(args.save_dir, exist_ok=True)
+
+    label_df = pd.read_csv(args.label_csv_path)
+    label_df = label_df.apply(lambda row: get_path(row, parent_dir=args.parent_dir), axis=1)
+    label_df = label_df[label_df["path"] != 0].reset_index(drop=True)
+    label_df["is_grid"] = label_df.apply(lambda row: 1 if row["Year"] >= 2017 else 0, axis=1)
+
+    label_df["save_path"] = label_df.apply(
+        lambda row: op.join(args.save_dir, f"{row['File_Name']}_{row['run_num']}"), axis=1
+    )
+    # Replace \\ with / to avoid path issues.
+    label_df["path"] = label_df["path"].apply(lambda x: x.replace("\\", "/"))
+    label_df["save_path"] = label_df["save_path"].apply(lambda x: x.replace("\\", "/"))
+    ## fix duplicated file names for saving purposes (modify the save_path in label_df accordingly)
+    label_df = fix_duplicated_save_paths(label_df, pdf_parent_dir=args.parent_dir, save_extension="")
+
+    label_df["ecg_format"] = label_df["is_grid"].apply(lambda has_grid: "new" if has_grid else "old")
+
+    label_df["file_exists"] = label_df["save_path"].apply(lambda x: op.exists(x))
+    to_process_df = label_df[label_df["file_exists"] == False].reset_index(drop=True).copy()
+
+    print(f"Processing {len(to_process_df)} files")
+    for _, row in tqdm(to_process_df.iterrows()):
+        result = preprocess(
+            row,
+        )
+        # results += [result]
+
+    label_df.drop(columns=["is_grid", "file_exists"], inplace=True)
+    label_df.to_csv(
+        args.label_save_path,
+        index=False,
+    )
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser()
+    parser.add_argument("--parent_dir", type=str, default="../datasets/siriraj_data/ECG_MRI")
+    parser.add_argument("--save_dir", type=str, default="../datasets/siriraj_data/ECG_MRI_1d_data_interp")
+    parser.add_argument("--label_csv_path", type=str, default="../datasets/all_ECG_cleared_duplicate_may23_final.csv")
+    parser.add_argument(
+        "--label_save_path", type=str, default="../datasets/all_ECG_cleared_duplicate_may23_final_1d_labels.csv"
+    )
+
+    args = parser.parse_args()
+    main(args)

--- a/scripts/train_1d.py
+++ b/scripts/train_1d.py
@@ -1,0 +1,339 @@
+import os
+import sys
+import json
+import os.path as op
+import numpy as np
+import pandas as pd
+from functools import partial
+import pytorch_lightning as pl
+from pytorch_lightning import LightningModule, Trainer, seed_everything
+from pytorch_lightning.callbacks import ModelCheckpoint, StochasticWeightAveraging, EarlyStopping
+from pytorch_lightning.loggers import WandbLogger
+
+from sklearn.experimental import enable_iterative_imputer
+from sklearn.impute import IterativeImputer
+import joblib
+from sklearn.linear_model import LinearRegression
+from scipy.signal import resample
+from sklearn.preprocessing import StandardScaler
+from tqdm.auto import tqdm
+
+tqdm.pandas()
+
+import biosppy
+import pickle
+import wandb
+import torch
+from torch.utils.data import DataLoader
+
+module_dir = op.join(op.dirname(op.abspath(__file__)), "..")
+sys.path.append(module_dir)
+from mtecg import (
+    ECG1DDataset,
+    ECGClinical1DDataset,
+    MultiTask1DDataset,
+    MultiTaskClinical1DDataset,
+    SingleTaskModel1D,
+    SingleTaskClinicalModel1D,
+    MultiTaskModel1D,
+    MultiTaskClinicalModel1D,
+)
+from mtecg.utils import load_ecg_dataframe_1d, find_best_thresholds, apply_thresholds
+import mtecg.constants as constants
+
+MODEL_TYPE_TO_CLASS_MAPPING = {
+    "single-task-1d": SingleTaskModel1D,
+    "single-task-clinical-1d": SingleTaskClinicalModel1D,
+    "multi-task-1d": MultiTaskModel1D,
+    "multi-task-clinical-1d": MultiTaskClinicalModel1D,
+}
+clinical_feature_columns = ["age", "female_gender", "dm", "ht", "smoke", "dlp"]
+
+ECG_FORMAT_TO_PAPER_PIXEL_SAMPLE_RATE = {"old": 294, "new": 280}
+
+
+def apply_rpeaks_normalization(lead_array_list, rpeak_index, ecg_format):
+    paper_pixel_sample_rate = ECG_FORMAT_TO_PAPER_PIXEL_SAMPLE_RATE[ecg_format]
+    start = max(0, int(rpeak_index - 0.5 * paper_pixel_sample_rate))
+    end = int(rpeak_index + 1.5 * paper_pixel_sample_rate)
+    return [lead[start:end] for lead in lead_array_list]
+
+
+def has_empty_leads(lead_array_list):
+    for lead in lead_array_list:
+        if len(lead) == 0:
+            return True
+    return False
+
+
+def filter_out_empty_leads(dataframe):
+    print(f"Shape Before filter out: {dataframe.shape}")
+    dataframe["has_empty_leads"] = dataframe["lead_arrays"].progress_apply(lambda lead_list: has_empty_leads(lead_list))
+    dataframe = dataframe[dataframe["has_empty_leads"] != True].reset_index(drop=True)
+    print(f"Shape After filter out: {dataframe.shape}")
+    return dataframe
+
+
+def process_dataframe(dataframe: pd.DataFrame, configs: dict, scaler: StandardScaler = None):
+    sample_rate = configs["sample_rate"]
+    scaler = StandardScaler() if scaler is None else scaler
+    dataframe["lead_arrays"] = dataframe[constants.path_column_name].progress_apply(
+        lambda x: pickle.load(open(x, "rb"))
+    )
+    dataframe["lead_arrays"] = dataframe.progress_apply(
+        lambda row: apply_rpeaks_normalization(row["lead_arrays"], row["median_first_rpeak_index"], row["ecg_format"]),
+        axis=1,
+    )
+    dataframe = filter_out_empty_leads(dataframe)
+    dataframe["lead_arrays"] = dataframe["lead_arrays"].progress_apply(
+        lambda lead_list: [resample(lead, sample_rate) for lead in lead_list]
+    )
+    scaler.fit(np.array(dataframe["lead_arrays"].tolist()).reshape(-1, 12))
+
+    dataframe["lead_arrays"] = dataframe["lead_arrays"].progress_apply(
+        lambda lead_list: scaler.transform(np.array(lead_list).reshape(-1, 12))
+    )
+    return dataframe, scaler
+
+
+def init_dataset(dataframe: pd.DataFrame, configs: dict):
+    model_type = configs["model_type"]
+    task = configs.get("task", "")
+    lvef_threshold = configs.get("lvef_threshold", None)
+
+    dataset_kwargs = {
+        "dataframe": dataframe,
+    }
+    # if lvef_threshold is not None:
+    #     dataset_kwargs["lvef_threshold"] = lvef_threshold
+
+    if "single" in model_type:
+        if task == "scar":
+            if "clinical" in model_type:
+                return ECGClinical1DDataset(**dataset_kwargs, label_column=constants.scar_label_column_name)
+            return ECG1DDataset(**dataset_kwargs, label_column=constants.scar_label_column_name)
+        elif task == "lvef":
+            if "clinical" in model_type:
+                return ECGClinical1DDataset(**dataset_kwargs, label_column=constants.lvef_label_column_name)
+            return ECG1DDataset(**dataset_kwargs, label_column=constants.lvef_label_column_name)
+        else:
+            raise ValueError(f"task {task} is not supported in single task model.")
+
+    elif "multi" in model_type:
+        if "clinical" in model_type:
+            return MultiTaskClinical1DDataset(**dataset_kwargs)
+        return MultiTask1DDataset(**dataset_kwargs)
+
+
+def get_dataloaders(data_dir: str, csv_path: str, configs: dict):
+    dataframe = load_ecg_dataframe_1d(csv_path, data_dir)
+    print(dataframe.shape)
+
+    save_dir = op.join(configs["parent_save_dir"], get_run_name(configs))
+    os.makedirs(save_dir, exist_ok=True)
+
+    # Combine old train and new train.
+    train_df = dataframe[dataframe.split.isin(["old_train", "new_train"])].reset_index()
+    # Combine old valid and new valid.
+    valid_df = dataframe[dataframe.split.isin(["old_valid", "new_valid"])].reset_index()
+
+    # Get the old train and valid if scheme is 'pretrain'.
+    if configs["dataset"] == "pretrain":
+        train_df = dataframe[dataframe.split.isin(["old_train"])].reset_index()
+        valid_df = dataframe[dataframe.split.isin(["old_valid"])].reset_index()
+    # Get the new train and valid if scheme is 'transfer'.
+    elif configs["dataset"] == "transfer":
+        train_df = dataframe[dataframe.split.isin(["new_train"])].reset_index()
+        valid_df = dataframe[dataframe.split.isin(["new_valid"])].reset_index()
+    elif configs["dataset"] == "all":
+        train_df = dataframe[dataframe.split.isin(["old_train", "new_train"])].reset_index()
+        valid_df = dataframe[dataframe.split.isin(["old_valid", "new_valid"])].reset_index()
+
+    if "clinical" in configs["model_type"]:
+        # Get imputer from train set.
+        imputer = get_imputer(train_df, configs)
+        # Impute missing values in the train set.
+        train_df[clinical_feature_columns] = imputer.transform(train_df[clinical_feature_columns])
+        # Impute missing values in the valid set.
+        valid_df[clinical_feature_columns] = imputer.transform(valid_df[clinical_feature_columns])
+
+        # Find the best thresholds for imputing missing values from the train set.
+        best_threshold_dict = find_best_thresholds(train_df)
+
+        # Save the best thresholds.
+        joblib.dump(
+            best_threshold_dict,
+            op.join(save_dir, "imputer_threshold_dict.joblib"),
+        )
+
+        # Apply the best thresholds to the train set and the valid set.
+        train_df = apply_thresholds(train_df, best_threshold_dict)
+        valid_df = apply_thresholds(valid_df, best_threshold_dict)
+
+    train_df, train_scaler = process_dataframe(train_df, configs)
+    valid_df, _ = process_dataframe(valid_df, configs, scaler=train_scaler)
+
+    scaler_save_path = op.join(configs["parent_save_dir"], get_run_name(configs), "scaler.joblib")
+    joblib.dump(train_scaler, scaler_save_path)
+
+    # Init datasets.
+    train_dataset = init_dataset(train_df, configs)
+    valid_dataset = init_dataset(valid_df, configs)
+
+    # Init dataloaders.
+    train_loader = DataLoader(
+        train_dataset,
+        batch_size=configs["batch_size"],
+        shuffle=True,
+        pin_memory=True,
+        num_workers=configs["num_workers"],
+    )
+    valid_loader = DataLoader(
+        valid_dataset,
+        batch_size=configs["batch_size"],
+        shuffle=False,
+        pin_memory=True,
+        num_workers=configs["num_workers"],
+    )
+
+    return train_loader, valid_loader
+
+
+def get_imputer(train_dataframe: pd.DataFrame, configs: dict):
+    # Init imputer.
+    imputer = IterativeImputer(missing_values=np.nan, max_iter=10, sample_posterior=True, random_state=42)
+
+    # Fit the imputer on the train set.
+    imputer.fit(train_dataframe[clinical_feature_columns])
+
+    # Save the imputer.
+    imputer_path = op.join(configs["parent_save_dir"], get_run_name(configs), "imputer.joblib")
+    joblib.dump(imputer, imputer_path)
+
+    return imputer
+
+
+def get_model(configs: dict):
+    model_type = configs["model_type"]
+    model_class = MODEL_TYPE_TO_CLASS_MAPPING[model_type]
+    model = model_class(**configs)
+    return model
+
+
+def setup_wandb_logger(project_name: str, configs: dict):
+    run = wandb.init(project=project_name, save_code=True)
+    run.log_code(".", include_fn=lambda path: path.endswith(".py"))
+    run.config.update(
+        {
+            "batch_size": configs["batch_size"],
+        }
+    )
+
+    wandb_logger = WandbLogger(
+        name=configs["backbone"],
+        project=project_name,
+        # log_model=True,
+    )
+    return wandb_logger
+
+
+def get_run_name(configs: dict):
+    run_suffix = f"{configs['sample_rate']}"
+    if "lvef_threshold" in configs.keys():
+        run_suffix += f"_LVEF{str(configs['lvef_threshold'])}"
+
+    if "clinical" in configs["model_type"]:
+        run_suffix += f"_{configs['rnn_type']}_dim{configs['rnn_output_size']}"
+
+    run_name = f"{configs['backbone']}_{run_suffix}"
+    return run_name
+
+
+def main(args):
+    SEED = 42
+    np.random.seed(SEED)
+    seed_everything(SEED, workers=True)
+    torch.manual_seed(SEED)
+    torch.backends.cudnn.deterministic = True
+    torch.backends.cudnn.benchmark = False
+    torch.cuda.manual_seed(SEED)
+
+    # Load configs.
+    configs = json.load(open(args.config_path))
+    # Create parent save dir.
+    parent_save_dir = configs["parent_save_dir"]
+    os.makedirs(parent_save_dir, exist_ok=True)
+    # Create run name.
+    run_name = get_run_name(configs)
+
+    # Init dataloaders.
+    train_loader, valid_loader = get_dataloaders(args.data_dir, args.csv_path, configs=configs)
+
+    # Init model.
+    model = get_model(configs)
+    if configs["dataset"] == "transfer":
+        # Explicitly specify train=True to instantiate the model with loss functions on the correct device.
+        model = model.from_configs(configs["pretrained_model_path"], train=True, device=configs["device"])
+
+    # Setup wandb logger.
+    wandb_logger = setup_wandb_logger(project_name=args.project_name, configs=configs)
+    wandb_logger.watch(
+        model,
+        # log_freq=300, # uncomment to log gradients
+        log_graph=True,
+    )
+
+    # Init callbacks.
+    checkpoint_callback = ModelCheckpoint(
+        filename=configs["backbone"] + "{val_acc:.2f}",
+        save_top_k=1,
+        verbose=True,
+        monitor="val_loss",
+        mode="min",
+    )
+
+    earlystop_callback = EarlyStopping(
+        monitor="val_loss",
+        mode="min",
+        patience=5,
+    )
+
+    # Init trainer.
+    accumulate_grad_batches = configs.get("accumulate_grad_batches", 1)
+    precision = configs.get("precision", "16-mixed")
+    trainer = pl.Trainer(
+        accelerator="gpu",
+        logger=wandb_logger,
+        max_epochs=configs["num_epochs"],
+        callbacks=[checkpoint_callback, earlystop_callback, StochasticWeightAveraging(1e-3)],
+        accumulate_grad_batches=accumulate_grad_batches,
+        precision=precision,
+        log_every_n_steps=1,
+    )
+
+    # Train model.
+    trainer.fit(
+        model,
+        train_dataloaders=train_loader,
+        val_dataloaders=valid_loader,
+    )
+
+    # Save model and configs.
+    trainer.save_checkpoint(op.join(parent_save_dir, run_name, "model.ckpt"))
+    model.save_configs(op.join(parent_save_dir, run_name))
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--data_dir", type=str, default="../datasets/siriraj_data/ECG_MRI_1d_data_interp/")
+    parser.add_argument(
+        "--csv_path", type=str, default="../datasets/all_ECG_cleared_duplicate_may23_final_1d_labels_with_rpeaks.csv"
+    )
+    parser.add_argument("--config_path", type=str, default="configs-1d/single-task-scar.json")
+
+    parser.add_argument("--project_name", type=str, default="mtecg")
+
+    args = parser.parse_args()
+    main(args)


### PR DESCRIPTION
This PR

- [x] Adds the preprocessing pipeline for extracting 1D signals from ECG images
- [x] Adds the `Dataset` classes for 1D data in each training scheme
- [x] Adds the 1D `Model` classes
- [x] Adds a utility function for loading the 1D data into a ready-to-use dataframe
- [x] Adds a script for training the 1D models
- [x] Modifies `ECGClassifier` to support both 1D and 2D models/input data
- [x] Adds helper functions for evaluating the 1D models
- [x] Adds a separate evaluation notebook for the 1D models